### PR TITLE
Fix typo on Sonarcloud's url

### DIFF
--- a/pages/bookmarks/software-dev-things.mdx
+++ b/pages/bookmarks/software-dev-things.mdx
@@ -109,7 +109,7 @@ import Callout from 'nextra-theme-docs/callout'
 | ---------------------------------------------------------------------------------------------- | :--------------------------------------------------- |
 | [Material Design Color Tool](https://material.io/resources/color/#!/?view.left=0&view.right=0) | Create and share color pallete tool                  |
 | [Supabase](https://supabase.io/)                                                               | Open source BaaS as Firebase Alternative (SQL Based) |
-| [Sonarcloud](sonarcloud.io)                                                                    | Code analyzer                                        |
+| [Sonarcloud](https://sonarcloud.io/)                                                           | Code analyzer                                        |
 | [CodeFactor](https://www.codefactor.io/)                                                       | Another Code analyzer                                |
 | [Depfu](https://depfu.com/)                                                                    | Automated Dependencies updater bot                   |
 | [Responsively](https://responsively.app/)                                                      | Helps to preview the UI responsively                 |


### PR DESCRIPTION
Missing protocol on Sonarcloud's URL, causing a broken URL (https://docs.yehezgun.com/bookmarks/sonarcloud.io instead of sonarcloud.io)